### PR TITLE
Add a custom profile and default content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-project-message": "^9.3",
         "drupal/core-recommended": "^9.3",
+        "drupal/default_content": "^2.0@alpha",
         "drupal/devel": "^4.1",
         "drupal/token": "^1.10",
         "drupal/webform": "^6.2@beta",
@@ -36,7 +37,8 @@
         "allow-plugins": {
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
-            "drupal/core-project-message": true
+            "drupal/core-project-message": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {
@@ -95,5 +97,8 @@
                 "      composer remove drupal/core-project-message"
             ]
         }
+    },
+    "require-dev": {
+        "drupal/coder": "^8.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "838b5d02860e5764b462a694655dcd82",
+    "content-hash": "d6eb65d601828a902876afe277ba76ff",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2321,6 +2321,82 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core."
+        },
+        {
+            "name": "drupal/default_content",
+            "version": "2.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/default_content.git",
+                "reference": "2.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/default_content-2.0.0-alpha1.zip",
+                "reference": "2.0.0-alpha1",
+                "shasum": "0d534ab8e44786a352e24c7cec3dc06bef155f66"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "require-dev": {
+                "drupal/paragraphs": "^1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-alpha1",
+                    "datestamp": "1595072288",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Sam152",
+                    "homepage": "https://www.drupal.org/user/1485048"
+                },
+                {
+                    "name": "andypost",
+                    "homepage": "https://www.drupal.org/user/118908"
+                },
+                {
+                    "name": "benjy",
+                    "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "jibran",
+                    "homepage": "https://www.drupal.org/user/1198144"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Imports default content when a module is enabled",
+            "homepage": "https://www.drupal.org/project/default_content",
+            "support": {
+                "source": "https://git.drupalcode.org/project/default_content"
+            }
         },
         {
             "name": "drupal/devel",
@@ -7201,15 +7277,352 @@
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "drupal/coder",
+            "version": "8.3.15",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/coder.git",
+                "reference": "0cfad3a21f1168bdc3030ae73351c31f88abba74"
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "ext-mbstring": "*",
+                "php": ">=7.1",
+                "sirbrillig/phpcs-variable-analysis": "^2.10",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6.0",
+                "symfony/yaml": ">=2.0.5"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4.9",
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\": "coder_sniffer/Drupal/",
+                    "DrupalPractice\\": "coder_sniffer/DrupalPractice/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Coder is a library to review Drupal code.",
+            "homepage": "https://www.drupal.org/project/coder",
+            "keywords": [
+                "code review",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/coder",
+                "source": "https://www.drupal.org/project/coder"
+            },
+            "time": "2022-04-02T17:56:30+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "4a07085f74cb1f3fc7103efa537d9f00ebb74ec7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/4a07085f74cb1f3fc7103efa537d9f00ebb74ec7",
+                "reference": "4a07085f74cb1f3fc7103efa537d9f00ebb74ec7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.3"
+            },
+            "time": "2022-06-14T11:40:08+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/c921498b474212fe4552928bbeb68d70250ce5e8",
+                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+                "sirbrillig/phpcs-import-detection": "^1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2022-02-21T17:01:13+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.3",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.7.1",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-25T10:58:12+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "drupal/default_content": 15,
         "drupal/webform": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -54,8 +54,8 @@ module:
   webform_node: 0
   webform_ui: 0
   views: 10
-  minimal: 1000
+  install_profile: 1000
 theme:
   bartik: 0
   seven: 0
-profile: minimal
+profile: install_profile

--- a/config/sync/views.view.webform_submissions.yml
+++ b/config/sync/views.view.webform_submissions.yml
@@ -19,156 +19,12 @@ base_table: webform_submission
 base_field: sid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 25
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50, 100, 200'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            webform_submission_bulk_form: webform_submission_bulk_form
-            sid: sid
-            in_draft: in_draft
-            sticky: sticky
-            locked: locked
-            created: created
-            completed: completed
-            remote_addr: remote_addr
-            view_webform_submission: view_webform_submission
-            edit_webform_submission: view_webform_submission
-          info:
-            webform_submission_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            sid:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            in_draft:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            sticky:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            locked:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            created:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            completed:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            remote_addr:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            view_webform_submission:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ' '
-              empty_column: false
-              responsive: ''
-            edit_webform_submission:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: created
-          empty_table: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: 'Webform submissions'
       fields:
         sid:
           id: sid
@@ -177,6 +33,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -233,9 +92,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -243,6 +99,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -288,8 +147,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -300,9 +159,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -310,6 +166,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -367,9 +226,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -377,6 +233,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -432,9 +291,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -442,6 +298,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -486,22 +344,43 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
-          entity_type: webform_submission
-          plugin_id: entity_link
-      filters: {  }
-      sorts: {  }
-      header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-      footer: {  }
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50, 100, 200'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
       empty:
         area_text_custom:
           id: area_text_custom
@@ -510,11 +389,11 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No submissions available.'
           plugin_id: text_custom
-      relationships: {  }
+          empty: true
+          content: 'No submissions available.'
+          tokenize: false
+      sorts: {  }
       arguments:
         webform_id:
           id: webform_id
@@ -551,6 +430,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: numeric
           default_action: ignore
           exception:
             value: all
@@ -565,8 +447,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -578,42 +460,16 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: numeric
-      display_extenders: {  }
+      filters: {  }
       filter_groups:
         operator: AND
         groups: {  }
-      title: 'Webform submissions'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user
-      tags: {  }
-  embed_administer:
-    display_plugin: embed
-    id: embed_administer
-    display_title: 'Embed: Administer'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      display_description: 'Administer submissions.'
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -625,6 +481,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -694,26 +551,56 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
-      defaults:
-        style: false
-        row: false
-        access: false
-        fields: false
-        filters: false
-        filter_groups: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
+      query:
+        type: views_query
         options:
-          perm: 'administer webform submission'
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags: {  }
+  embed_administer:
+    id: embed_administer
+    display_title: 'Embed: Administer'
+    display_plugin: embed
+    position: 2
+    display_options:
       fields:
         webform_submission_bulk_form:
           id: webform_submission_bulk_form
@@ -722,6 +609,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: webform_submission_bulk_form
           label: 'Webform submission operations bulk form'
           exclude: false
           alter:
@@ -766,8 +655,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: webform_submission
-          plugin_id: webform_submission_bulk_form
         sid:
           id: sid
           table: webform_submission
@@ -775,6 +662,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -831,9 +721,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -841,6 +728,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -886,8 +776,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -898,9 +788,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -908,6 +795,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -953,8 +843,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -965,9 +855,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -975,6 +862,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -1020,8 +910,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1032,9 +922,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -1042,6 +929,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -1099,9 +989,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -1109,6 +996,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -1166,9 +1056,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -1176,6 +1063,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -1231,9 +1121,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         operations:
           id: operations
           table: webform_submission
@@ -1241,6 +1128,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -1283,9 +1173,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: null
-          entity_field: null
-          plugin_id: entity_operations
+      access:
+        type: perm
+        options:
+          perm: 'administer webform submission'
       filters:
         in_draft:
           id: in_draft
@@ -1294,6 +1185,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1304,6 +1198,8 @@ display:
             description: ''
             use_operator: false
             operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: in_draft
             required: false
             remember: false
@@ -1312,8 +1208,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1326,9 +1220,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
         sticky:
           id: sticky
           table: webform_submission
@@ -1336,6 +1227,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1346,6 +1240,8 @@ display:
             description: ''
             use_operator: false
             operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: sticky
             required: false
             remember: false
@@ -1354,8 +1250,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1368,9 +1262,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
         locked:
           id: locked
           table: webform_submission
@@ -1378,6 +1269,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1388,6 +1282,8 @@ display:
             description: ''
             use_operator: false
             operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: locked
             required: false
             remember: false
@@ -1397,8 +1293,6 @@ display:
               anonymous: '0'
               administrator: '0'
               demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1411,13 +1305,119 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            webform_submission_bulk_form: webform_submission_bulk_form
+            sid: sid
+            in_draft: in_draft
+            sticky: sticky
+            locked: locked
+            created: created
+            completed: completed
+            remote_addr: remote_addr
+            view_webform_submission: view_webform_submission
+            edit_webform_submission: view_webform_submission
+          default: created
+          info:
+            webform_submission_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            in_draft:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sticky:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            locked:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            completed:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            remote_addr:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_webform_submission:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ' '
+              empty_column: false
+              responsive: ''
+            edit_webform_submission:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Administer submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -1429,36 +1429,24 @@ display:
         - user.permissions
       tags: {  }
   embed_default:
-    display_plugin: embed
     id: embed_default
     display_title: 'Embed: Default'
+    display_plugin: embed
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: 'Display submissions.'
-      defaults:
-        fields: true
-        style: false
-        row: false
-        filters: true
-        filter_groups: true
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             sid: sid
             in_draft: in_draft
             created: created
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
+          default: created
           info:
             sid:
               sortable: true
@@ -1495,15 +1483,27 @@ display:
               separator: ' '
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
+      defaults:
+        style: false
+        row: false
+        fields: true
+        filters: true
+        filter_groups: true
+      display_description: 'Display submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1514,13 +1514,11 @@ display:
         - user
       tags: {  }
   embed_manage:
-    display_plugin: embed
     id: embed_manage
     display_title: 'Embed: Manage'
+    display_plugin: embed
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: 'Manage submissions.'
       fields:
         webform_submission_bulk_form:
           id: webform_submission_bulk_form
@@ -1529,6 +1527,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: webform_submission_bulk_form
           label: 'Webform submission operations bulk form'
           exclude: false
           alter:
@@ -1577,8 +1577,6 @@ display:
             - webform_submission_make_sticky_action
             - webform_submission_make_unlock_action
             - webform_submission_make_unsticky_action
-          entity_type: webform_submission
-          plugin_id: webform_submission_bulk_form
         sid:
           id: sid
           table: webform_submission
@@ -1586,6 +1584,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -1642,9 +1643,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -1652,6 +1650,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -1697,8 +1698,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1709,9 +1710,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -1719,6 +1717,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -1764,8 +1765,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1776,9 +1777,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -1786,6 +1784,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -1831,8 +1832,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1843,9 +1844,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -1853,6 +1851,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -1910,9 +1911,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -1920,6 +1918,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -1977,9 +1978,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -1987,6 +1985,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -2042,9 +2043,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -2052,6 +2050,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -2096,8 +2096,6 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
-          entity_type: webform_submission
-          plugin_id: entity_link
         edit_webform_submission:
           id: edit_webform_submission
           table: webform_submission
@@ -2105,6 +2103,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link_edit
           label: Operations
           exclude: false
           alter:
@@ -2149,26 +2149,148 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
+      access:
+        type: perm
+        options:
+          perm: 'edit any webform submission'
+      filters:
+        in_draft:
+          id: in_draft
+          table: webform_submission
+          field: in_draft
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
-          plugin_id: entity_link_edit
-      defaults:
-        fields: false
-        style: false
-        row: false
-        access: false
-        filters: false
-        filter_groups: false
+          entity_field: in_draft
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Is draft'
+            description: ''
+            use_operator: false
+            operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: in_draft
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        sticky:
+          id: sticky
+          table: webform_submission
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        locked:
+          id: locked
+          table: webform_submission
+          field: locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Locked
+            description: ''
+            use_operator: false
+            operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: locked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              demo_region: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -2180,6 +2302,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -2249,151 +2372,28 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
-        options:
-          perm: 'edit any webform submission'
-      filters:
-        in_draft:
-          id: in_draft
-          table: webform_submission
-          field: in_draft
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Is draft'
-            description: ''
-            use_operator: false
-            operator: in_draft_op
-            identifier: in_draft
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
-        sticky:
-          id: sticky
-          table: webform_submission
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
-        locked:
-          id: locked
-          table: webform_submission
-          field: locked
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Locked
-            description: ''
-            use_operator: false
-            operator: locked_op
-            identifier: locked
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Manage submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -2405,13 +2405,11 @@ display:
         - user.permissions
       tags: {  }
   embed_review:
-    display_plugin: embed
     id: embed_review
     display_title: 'Embed: Review'
+    display_plugin: embed
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: 'Review submissions.'
       fields:
         sid:
           id: sid
@@ -2420,6 +2418,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -2476,9 +2477,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -2486,6 +2484,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -2531,8 +2532,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2543,9 +2544,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -2553,6 +2551,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -2598,8 +2599,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2610,9 +2611,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -2620,6 +2618,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -2665,8 +2666,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2677,9 +2678,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -2687,6 +2685,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -2744,9 +2745,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -2754,6 +2752,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -2811,9 +2812,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -2821,6 +2819,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -2876,9 +2877,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -2886,6 +2884,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -2930,26 +2930,148 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
+      access:
+        type: perm
+        options:
+          perm: 'view any webform submission'
+      filters:
+        in_draft:
+          id: in_draft
+          table: webform_submission
+          field: in_draft
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
-          plugin_id: entity_link
-      defaults:
-        fields: false
-        style: false
-        row: false
-        access: false
-        filters: false
-        filter_groups: false
+          entity_field: in_draft
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Is draft'
+            description: ''
+            use_operator: false
+            operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: in_draft
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        sticky:
+          id: sticky
+          table: webform_submission
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        locked:
+          id: locked
+          table: webform_submission
+          field: locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Locked
+            description: ''
+            use_operator: false
+            operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: locked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              demo_region: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -2961,6 +3083,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -3030,151 +3153,28 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
-        options:
-          perm: 'view any webform submission'
-      filters:
-        in_draft:
-          id: in_draft
-          table: webform_submission
-          field: in_draft
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Is draft'
-            description: ''
-            use_operator: false
-            operator: in_draft_op
-            identifier: in_draft
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
-        sticky:
-          id: sticky
-          table: webform_submission
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
-        locked:
-          id: locked
-          table: webform_submission
-          field: locked
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Locked
-            description: ''
-            use_operator: false
-            operator: locked_op
-            identifier: locked
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Review submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/modules/custom/sb_default_content/content/menu_link_content/cc32df13-f2c3-4abe-a83f-4e09ac9dfae8.yml
+++ b/web/modules/custom/sb_default_content/content/menu_link_content/cc32df13-f2c3-4abe-a83f-4e09ac9dfae8.yml
@@ -1,0 +1,29 @@
+_meta:
+  version: "1.0"
+  entity_type: menu_link_content
+  uuid: cc32df13-f2c3-4abe-a83f-4e09ac9dfae8
+  bundle: menu_link_content
+  default_langcode: en
+  depends:
+    e5eae0cd-34f2-4de8-88d3-6688017cf87b: node
+default:
+  enabled:
+    - value: true
+  title:
+    - value: "Contact us"
+  menu_name:
+    - value: main
+  link:
+    - target_uuid: e5eae0cd-34f2-4de8-88d3-6688017cf87b
+      title: ""
+      options: {}
+  external:
+    - value: false
+  rediscover:
+    - value: false
+  weight:
+    - value: 10
+  expanded:
+    - value: false
+  revision_translation_affected:
+    - value: true

--- a/web/modules/custom/sb_default_content/content/node/e5eae0cd-34f2-4de8-88d3-6688017cf87b.yml
+++ b/web/modules/custom/sb_default_content/content/node/e5eae0cd-34f2-4de8-88d3-6688017cf87b.yml
@@ -1,0 +1,42 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: e5eae0cd-34f2-4de8-88d3-6688017cf87b
+  bundle: webform
+  default_langcode: en
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Contact us'
+  created:
+    -
+      value: 1655739131
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  path:
+    -
+      alias: /contact
+      langcode: en
+  webform:
+    -
+      target_id: contact_us
+      default_data: ''
+      status: open
+      open: ''
+      close: ''

--- a/web/modules/custom/sb_default_content/sb_default_content.info.yml
+++ b/web/modules/custom/sb_default_content/sb_default_content.info.yml
@@ -1,0 +1,11 @@
+name: Stand Blog Default Content
+type: module
+description: "Provides default content"
+package: Stand Blog
+core_version_requirement: ^9
+
+default_content:
+  node:
+    - e5eae0cd-34f2-4de8-88d3-6688017cf87b
+  menu_link_content:
+    - cc32df13-f2c3-4abe-a83f-4e09ac9dfae8

--- a/web/profiles/install_profile/install_profile.info.yml
+++ b/web/profiles/install_profile/install_profile.info.yml
@@ -1,0 +1,4 @@
+name: Stand Blog install profile
+type: profile
+description: "Builds a Stand Blog site."
+core_version_requirement: ^9

--- a/web/profiles/install_profile/install_profile.links.menu.yml
+++ b/web/profiles/install_profile/install_profile.links.menu.yml
@@ -1,0 +1,4 @@
+install_profile.front_page:
+  title: "Home"
+  route_name: "<front>"
+  menu_name: main

--- a/web/profiles/install_profile/install_profile.profile
+++ b/web/profiles/install_profile/install_profile.profile
@@ -1,0 +1,33 @@
+<?php // phpcs:ignore Drupal.Commenting.FileComment.Missing
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Profile containing customizations.
+ */
+
+/**
+ * @return array<string, array>
+ */
+function install_profile_install_tasks(&$install_state): array {
+  $tasks = [];
+  $tasks['install_profile_finish_installation'] = [
+    'display_name' => t('Install default content'),
+  ];
+  return $tasks;
+}
+
+/**
+ * Finish installation process.
+ *
+ * @param array $install_state
+ *   The install state.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function install_profile_finish_installation(array &$install_state): void {
+  \Drupal::service('module_installer')->install(['default_content']);
+  \Drupal::service('default_content.importer')->importContent('sb_default_content');
+  \Drupal::service('module_installer')->uninstall(['serialization', 'hal', 'default_content']);
+}


### PR DESCRIPTION
## Issue
Fixes #…

## Description
Creates a custom profile called: `install_profile` and set up instead of `minimal`.

Added the `default_content` contrib module with two content: The contact form page and the the main menu link.

## Test Instructions
`ddev composer install`
`ddev si --existing-config`

After site install the Contact us menu link should be in the main menu along side the Home link.
One weborm node called `Contact us` should be set up with the default content.

## Approach (be as specific as possible)
With a custom profile we have more global control, e.g create general tests, or make custom logic for install modules.
Default content data used for demoing the progress and posibly it can work as the base content for the site.

## Screenshots
<!-- (optional) Should always be added for visual changes. Makes reviewing much easier. -->


## Deployment
<!-- (optional) Typically not needed, but any manual steps required for deployment. -->
