### PR TITLE
Create a landing page with two blocks types using Layoutbuilder

### DIFF
--- a/config/sync/block_content.type.media.yml
+++ b/config/sync/block_content.type.media.yml
@@ -1,0 +1,8 @@
+uuid: c3330ae2-9e91-4d38-a62e-5390638f8bc8
+langcode: en
+status: true
+dependencies: {  }
+id: media
+label: Media
+revision: 0
+description: ''

--- a/config/sync/core.entity_form_display.block_content.media.default.yml
+++ b/config/sync/core.entity_form_display.block_content.media.default.yml
@@ -1,0 +1,42 @@
+uuid: 532cb83c-0e34-452a-bc50-d4d132953fdd
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.media
+    - field.field.block_content.media.body
+    - field.field.block_content.media.field_media
+  module:
+    - media_library
+    - text
+id: block_content.media.default
+targetEntityType: block_content
+bundle: media
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 26
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_media:
+    type: media_library_widget
+    weight: 27
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_form_display.node.blog_post.default.yml
+++ b/config/sync/core.entity_form_display.node.blog_post.default.yml
@@ -18,7 +18,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 121
+    weight: 7
     region: content
     settings:
       rows: 9
@@ -28,20 +28,20 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   field_image:
     type: media_library_widget
-    weight: 124
+    weight: 9
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete
-    weight: 123
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -51,34 +51,34 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -86,7 +86,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -1,67 +1,65 @@
-uuid: 80e0a6ee-33d2-49b3-8e63-e2b5ece670e1
+uuid: 85958168-d81d-456f-ae00-1ba58a4dee19
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.webform.body
-    - field.field.node.webform.webform
-    - node.type.webform
+    - field.field.node.landing_page.body
+    - field.field.node.landing_page.layout_builder__layout
+    - node.type.landing_page
   module:
     - path
     - text
-    - webform
-_core:
-  default_config_hash: A3evv2pt6d-bKCPcgjXA5VGTemXWOxG3lSXvWiRWcck
-id: node.webform.default
+id: node.landing_page.default
 targetEntityType: node
-bundle: webform
+bundle: landing_page
 mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 0
+    weight: 6
     region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
+      show_summary: false
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -69,17 +67,13 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  webform:
-    type: webform_entity_reference_select
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-hidden: {  }
+hidden:
+  layout_builder__layout: true

--- a/config/sync/core.entity_view_display.block_content.media.default.yml
+++ b/config/sync/core.entity_view_display.block_content.media.default.yml
@@ -1,0 +1,24 @@
+uuid: c87dc402-54ea-4fa6-b0bf-15809a53e2de
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.media
+    - field.field.block_content.media.body
+    - field.field.block_content.media.field_media
+id: block_content.media.default
+targetEntityType: block_content
+bundle: media
+mode: default
+content:
+  field_media:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -1,0 +1,68 @@
+uuid: f0b8bfe7-3561-45b3-b11d-7d090b66d649
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.landing_page.body
+    - field.field.node.landing_page.layout_builder__layout
+    - node.type.landing_page
+  module:
+    - layout_builder
+    - layout_discovery
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: true
+    allow_custom: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+        components:
+          5d4b5d39-5b21-4068-ad34-e56bb4321b42:
+            uuid: 5d4b5d39-5b21-4068-ad34-e56bb4321b42
+            region: content
+            configuration:
+              id: 'extra_field_block:node:landing_page:links'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+            weight: 0
+            additional: {  }
+          90276ea7-23a0-446a-bd73-6a1255752f04:
+            uuid: 90276ea7-23a0-446a-bd73-6a1255752f04
+            region: content
+            configuration:
+              id: 'field_block:node:landing_page:body'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: text_default
+                label: hidden
+                settings: {  }
+                third_party_settings: {  }
+            weight: 1
+            additional: {  }
+        third_party_settings: {  }
+id: node.landing_page.default
+targetEntityType: node
+bundle: landing_page
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  layout_builder__layout: true

--- a/config/sync/core.entity_view_display.node.landing_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.teaser.yml
@@ -1,20 +1,18 @@
-uuid: 2b607223-8a4b-449e-85a0-6a2fa46a8fe3
+uuid: 23c3082a-9c04-4e67-b24e-31706076c7b7
 langcode: en
 status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.webform.body
-    - field.field.node.webform.webform
-    - node.type.webform
+    - field.field.node.landing_page.body
+    - field.field.node.landing_page.layout_builder__layout
+    - node.type.landing_page
   module:
     - text
     - user
-_core:
-  default_config_hash: Ls5l3Xs7-YstJnurxFLKj38Exqr2JMZs1j9YeX1Kh2o
-id: node.webform.teaser
+id: node.landing_page.teaser
 targetEntityType: node
-bundle: webform
+bundle: landing_page
 mode: teaser
 content:
   body:
@@ -31,4 +29,4 @@ content:
     weight: 100
     region: content
 hidden:
-  webform: true
+  layout_builder__layout: true

--- a/config/sync/core.entity_view_display.node.webform.default.yml
+++ b/config/sync/core.entity_view_display.node.webform.default.yml
@@ -18,22 +18,22 @@ bundle: webform
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 101
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 101
     region: content
   links:
-    weight: 100
     settings: {  }
     third_party_settings: {  }
+    weight: 100
     region: content
   webform:
-    weight: 102
+    type: webform_entity_reference_entity_view
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: webform_entity_reference_entity_view
+    weight: 102
     region: content
 hidden: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -28,6 +28,8 @@ module:
   help: 0
   history: 0
   image: 0
+  layout_builder: 0
+  layout_discovery: 0
   link: 0
   media: 0
   media_library: 0

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -7,3 +7,9 @@ definitions:
     weight: 0
     expanded: false
     enabled: true
+  install_profile__front_page:
+    weight: -50
+    menu_name: main
+    parent: ''
+    expanded: false
+    enabled: true

--- a/config/sync/field.field.block_content.media.body.yml
+++ b/config/sync/field.field.block_content.media.body.yml
@@ -1,0 +1,23 @@
+uuid: abd9028d-6998-49e2-a92b-23a414d97a26
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.media
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.media.body
+field_name: body
+entity_type: block_content
+bundle: media
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/field.field.block_content.media.field_media.yml
+++ b/config/sync/field.field.block_content.media.field_media.yml
@@ -1,0 +1,29 @@
+uuid: ecff0bf0-2194-4fc5-9839-e9956d30d5c2
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.media
+    - field.storage.block_content.field_media
+    - media.type.image
+id: block_content.media.field_media
+field_name: field_media
+entity_type: block_content
+bundle: media
+label: Media
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.landing_page.body.yml
+++ b/config/sync/field.field.node.landing_page.body.yml
@@ -1,0 +1,23 @@
+uuid: d1f98aa1-4bd3-4943-a6d1-86a1679a4c5b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.landing_page
+  module:
+    - text
+id: node.landing_page.body
+field_name: body
+entity_type: node
+bundle: landing_page
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/field.field.node.landing_page.layout_builder__layout.yml
+++ b/config/sync/field.field.node.landing_page.layout_builder__layout.yml
@@ -1,0 +1,21 @@
+uuid: 01c22f30-f4f8-4ed6-a446-c3c9517183c7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.layout_builder__layout
+    - node.type.landing_page
+  module:
+    - layout_builder
+id: node.landing_page.layout_builder__layout
+field_name: layout_builder__layout
+entity_type: node
+bundle: landing_page
+label: Layout
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: layout_section

--- a/config/sync/field.field.node.webform.webform.yml
+++ b/config/sync/field.field.node.webform.webform.yml
@@ -19,11 +19,11 @@ required: false
 translatable: false
 default_value:
   -
+    target_uuid: ''
     default_data: ''
     status: open
     open: ''
     close: ''
-    target_uuid: ''
 default_value_callback: ''
 settings:
   handler: 'default:webform'

--- a/config/sync/field.storage.block_content.field_media.yml
+++ b/config/sync/field.storage.block_content.field_media.yml
@@ -1,0 +1,20 @@
+uuid: fd76fe33-feae-4bac-b58d-7ef555a932db
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - media
+id: block_content.field_media
+field_name: field_media
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.layout_builder__layout.yml
+++ b/config/sync/field.storage.node.layout_builder__layout.yml
@@ -1,0 +1,19 @@
+uuid: 3a5fd6a0-d100-484c-9cd7-173209122b15
+langcode: en
+status: true
+dependencies:
+  module:
+    - layout_builder
+    - node
+id: node.layout_builder__layout
+field_name: layout_builder__layout
+entity_type: node
+type: layout_section
+settings: {  }
+module: layout_builder
+locked: true
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/node.type.landing_page.yml
+++ b/config/sync/node.type.landing_page.yml
@@ -1,0 +1,18 @@
+uuid: 6bd16346-80cc-4886-8fd7-c9a6663b2ed5
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: 'Landing page'
+type: landing_page
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true


### PR DESCRIPTION
## Issue
Fixes #…

- Create a Landing Page Content type with no fields only Title. Enable this conten type to use Layout builder for in its Manage Display settings.

1. Install contrib module Layout builder and layout builder required
2. Add layour builder to the Page Stand blog

-  Create two new Block types. Text with a body field and Image with a media reference that allow us to create images.

1. add two new block types. one with a body to put information about us so, and other to put image. both creat a block types text and media. required media library

-  To test things. Create the About Us content and then use the Layout tab to add inline blocks using the add custom block section when adding a block for a section.

1. add to new content called About Us inline using custom block with tow section.


![image](https://user-images.githubusercontent.com/102109226/178125879-c6b76a6a-4a04-4162-9d96-092cf82d2e4e.png)
